### PR TITLE
Enable triple store load monitoring and pr.owl work-around

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 RUN git clone -b kabob.docker http://github.com/bill-baumgartner/datasource ./datasource.git && \
     mvn clean install -f ./datasource.git/pom.xml
 
-RUN git clone -b docker.dev.load_request https://github.com/bill-baumgartner/kabob ./kabob.git && \
+RUN git clone -b docker.base https://github.com/bill-baumgartner/kabob ./kabob.git && \
     mvn clean install -f ./kabob.git/pom.xml && \
     mvn clean package -f ./kabob.git/scripts/download/pom-flatten-ontology.xml    
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN git clone -b docker.dev.load_request https://github.com/bill-baumgartner/kab
     mvn clean install -f ./kabob.git/pom.xml && \
     mvn clean package -f ./kabob.git/scripts/download/pom-flatten-ontology.xml    
 
-COPY scripts/setup.sh scripts/download-ontologies.sh scripts/other-downloads.sh scripts/ice-rdf-gen.sh /
+COPY scripts/setup.sh scripts/download-ontologies.sh scripts/other-downloads.sh scripts/ice-rdf-gen.sh scripts/fix-pr-invalid-xml.sh /
 
 RUN chmod 755 ./*.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,13 @@ RUN apt-get update && apt-get install -y \
     maven \
     git \
     unzip \
-    wget
+    wget \
+    inotify-tools
 
 RUN git clone -b kabob.docker http://github.com/bill-baumgartner/datasource ./datasource.git && \
     mvn clean install -f ./datasource.git/pom.xml
 
-RUN git clone -b docker.base https://github.com/bill-baumgartner/kabob ./kabob.git && \
+RUN git clone -b docker.dev.load_request https://github.com/bill-baumgartner/kabob ./kabob.git && \
     mvn clean install -f ./kabob.git/pom.xml && \
     mvn clean package -f ./kabob.git/scripts/download/pom-flatten-ontology.xml    
 

--- a/scripts/fix-pr-invalid-xml.sh
+++ b/scripts/fix-pr-invalid-xml.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+
+# This fixes some ampersands that need to be escaped in the pr.owl file
+echo "Fixing invalid XML in pr.owl..."
+sed -i "s/\&name/\&amp;name/g" /kabob_data/ontology/pr.owl

--- a/scripts/other-downloads.sh
+++ b/scripts/other-downloads.sh
@@ -5,4 +5,4 @@
 mkdir -p /kabob_data/raw/irefweb
 
 # wget the irefweb file using an automated retry-on-failure flag
-cd /kabob_data/raw/irefweb && { wget -c -t 0 --timeout 60 --waitretry 10 http://irefindex.org/download/irefindex/data/archive/release_14.0/psi_mitab/MITAB2.6/9606.mitab.07042015.txt.zip ; unzip 9606.mitab.07042015.txt.zip ; touch 9606.mitab.04072015.txt.ready ; cd - ; }
+cd /kabob_data/raw/irefweb && { wget -c -t 0 --timeout 60 --waitretry 10 http://irefindex.org/download/irefindex/data/archive/release_14.0/psi_mitab/MITAB2.6/9606.mitab.07042015.txt.zip ; unzip -o 9606.mitab.07042015.txt.zip ; touch 9606.mitab.04072015.txt.ready ; cd - ; }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,3 +6,4 @@ mkdir -p /kabob_data/logs
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $SCRIPT_DIR/download-ontologies.sh
 $SCRIPT_DIR/other-downloads.sh
+$SCRIPT_DIR/fix-pr-invalid-xml.sh


### PR DESCRIPTION
This PR serves two main functions:

1) The inotify-tools package was added to the KaBOB container to facilitate the monitoring of triple store loads. When a load is submitted, the inotifywait command is used to monitor the submittion directory for a .success or .error file indicating the outcome of the load.

2) This PR also includes a script that fixes invalid XML in the pr.owl file. The invalid XML prevents the pr.owl file from being loaded and processed.