### PR TITLE
Incorporating an updated datasource project that generates metadata RDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     inotify-tools
 
-RUN git clone --branch kabob.docker_v0.2 http://github.com/bill-baumgartner/datasource ./datasource.git && \
+RUN git clone --branch kabob.docker_v0.2.1 http://github.com/bill-baumgartner/datasource ./datasource.git && \
     mvn clean install -f ./datasource.git/pom.xml
 
 RUN git clone --branch kabob.docker_v0.2 https://github.com/bill-baumgartner/kabob ./kabob.git && \

--- a/scripts/other-downloads.sh
+++ b/scripts/other-downloads.sh
@@ -4,5 +4,7 @@
 # prematurely so we use curl here to download the human irefweb file
 mkdir -p /kabob_data/raw/irefweb
 
+DATE=$(date +%m/%d/%Y)
+
 # wget the irefweb file using an automated retry-on-failure flag
-cd /kabob_data/raw/irefweb && { wget -c -t 0 --timeout 60 --waitretry 10 http://irefindex.org/download/irefindex/data/archive/release_14.0/psi_mitab/MITAB2.6/9606.mitab.07042015.txt.zip ; unzip -o 9606.mitab.07042015.txt.zip ; touch 9606.mitab.04072015.txt.ready ; cd - ; }
+cd /kabob_data/raw/irefweb && { wget -c -t 0 --timeout 60 --waitretry 10 http://irefindex.org/download/irefindex/data/archive/release_14.0/psi_mitab/MITAB2.6/9606.mitab.07042015.txt.zip ; unzip -o 9606.mitab.07042015.txt.zip ; touch 9606.mitab.04072015.txt.ready ; touch -mt 1504070000 9606.mitab.04072015.txt ; echo "DOWNLOAD_DATE=$DATE" > 9606.mitab.04072015.txt.ready ; echo "FILE_SIZE_IN_BYTES=793647006" >> 9606.mitab.04072015.txt.ready ; echo "DOWNLOAD_URL=http://irefindex.org/download/irefindex/data/archive/release_14.0/psi_mitab/MITAB2.6/9606.mitab.07042015.txt.zip" >> 9606.mitab.04072015.txt.ready ; echo "DOWNLOADED_FILE=/kabob_data/raw/irefweb/9606.mitab.04072015.txt" >> 9606.mitab.04072015.txt.ready ;  echo "FILE_LAST_MOD_DATE=04/07/2015" >> 9606.mitab.04072015.txt.ready ; cd - ; }


### PR DESCRIPTION
The updated version of the datasource project (kabob.docker_v0.2.1) now includes metadata for each data source with the ICE RDF that it generates. This metadata includes information such as the date of download, file size, download URL, downloaded file location, and downloaded file last-modified date. The metadata is stored in the .ready file that signals the completion of a file download.

Because the irefweb data source is downloaded separately using wget, the download script was updated to create a similar .ready file with the relevant metadata pertaining to irefweb. 